### PR TITLE
Add utility function to cleanup routes with duplicate shapeMeta

### DIFF
--- a/src/Itinero.Instructions/RouteExtensions.cs
+++ b/src/Itinero.Instructions/RouteExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Itinero.Routes;
+﻿using System.Collections.Generic;
+using Itinero.Routes;
 
 namespace Itinero.Instructions;
 
@@ -22,4 +23,43 @@ public static class RouteExtensions
 
         return generator.Generate();
     }
+    
+    /// <summary>
+    ///     Checks the `ShapeMeta` of the route and removes shapeMeta's where multiple metadata point to the same Shape
+    /// </summary>
+    /// <param name="route">The route to clean up. This will be cleaned inline and thus change the object</param>
+    /// <param name="keepFirst">
+    ///     The strategy. If a duplicate is encountered, the first will be kept if true, the last if set to
+    ///     false
+    /// </param>
+    /// <returns>The original reference is returned</returns>
+    public static Route RemoveDuplicateShapeMeta(this Route route,
+        bool keepFirst = true)
+    {
+        var oldShapeMeta = route.ShapeMeta;
+        var newShapeMeta = new List<Route.Meta>();
+        var lastIndex = -1;
+        foreach (var meta in oldShapeMeta)
+        {
+            if (lastIndex != meta.Shape)
+            {
+                newShapeMeta.Add(meta);
+                lastIndex = meta.Shape;
+                continue;
+            }
+
+            if (keepFirst)
+            {
+                continue;
+            }
+
+            newShapeMeta[^1] = meta;
+            lastIndex = meta.Shape;
+        }
+
+        route.ShapeMeta = newShapeMeta;
+
+        return route;
+    }
+
 }

--- a/test/Itinero.Tests/Instructions/RouteExtensionsTest.cs
+++ b/test/Itinero.Tests/Instructions/RouteExtensionsTest.cs
@@ -1,0 +1,103 @@
+using System.Linq;
+
+namespace Itinero.Tests.Instructions;
+using System.Collections.Generic;
+using Itinero.Instructions;
+using Itinero.Routes;
+using Xunit;
+
+public class RouteExtensionsTest
+{
+    
+    [Fact]
+    public void DirectionChangeAt_SimpleRightTurn_IsNegative()
+    {
+        var r = new Route
+        {
+            Shape = new List<(double longitude, double latitude, float? e)>
+            {
+                (3.2200763, 51.2159230, 0), (3.2203252, 51.215485, 0), (3.2195995, 51.215298, 0)
+            },
+            ShapeMeta = new List<Route.Meta>
+            {
+                new Route.Meta()
+                {
+                    Shape = 2,
+                    Attributes = new List<(string key, string value)>
+                    {
+                        ("name","teststreet")
+                    }
+                }
+            }
+        };
+        var angleDiff = new IndexedRoute(r).DirectionChangeAt(1);
+        Assert.True(angleDiff < 0);
+        Assert.True(-95 < angleDiff && angleDiff < -85);
+    }
+    [Fact]
+    public void RouteExtensions_RemoveDuplicates_KeepLast_SimpleRoute_CleanedShapeMeta(){
+        var r = new Route
+        {
+            Shape = new List<(double longitude, double latitude, float? e)>
+            {
+                (3.2200763, 51.2159230, 0), (3.2203252, 51.215485, 0), (3.2195995, 51.215298, 0)
+            },
+            ShapeMeta = new List<Route.Meta>
+            {new Route.Meta()
+                {
+                    Shape = 2,
+                    Attributes = new List<(string key, string value)>
+                    {
+                        ("ref","0")
+                    }
+                },
+                new Route.Meta()
+                {
+                    Shape = 2,
+                    Attributes = new List<(string key, string value)>
+                    {
+                        ("ref","1")
+                    }
+                }
+            }
+        };
+        r.RemoveDuplicateShapeMeta();
+        Assert.Single(r.ShapeMeta);
+       
+        Assert.Equal("0",  r.ShapeMeta[0].Attributes.ToList()[0].value);
+    }
+    
+    
+    [Fact]
+    public void RouteExtensions_RemoveDuplicates_SimpleRoute_CleanedShapeMeta(){
+        var r = new Route
+        {
+            Shape = new List<(double longitude, double latitude, float? e)>
+            {
+                (3.2200763, 51.2159230, 0), (3.2203252, 51.215485, 0), (3.2195995, 51.215298, 0)
+            },
+            ShapeMeta = new List<Route.Meta>
+            {new Route.Meta()
+                {
+                    Shape = 2,
+                    Attributes = new List<(string key, string value)>
+                    {
+                        ("ref","0")
+                    }
+                },
+                new Route.Meta()
+                {
+                    Shape = 2,
+                    Attributes = new List<(string key, string value)>
+                    {
+                        ("ref","1")
+                    }
+                }
+            }
+        };
+        r.RemoveDuplicateShapeMeta(false); // Keep last
+        Assert.Single(r.ShapeMeta);
+       
+        Assert.Equal("1",  r.ShapeMeta[0].Attributes.ToList()[0].value);
+    }
+}


### PR DESCRIPTION
In some cases, the instruction generation code might generate routes where multiple shape-metas give information about the same shape. This causes crashes in some code.

This utility-function gives the routing-api the possibility to clean this up.