### PR TITLE
Fix angles

### DIFF
--- a/src/Itinero.Instructions/IndexedRoute.cs
+++ b/src/Itinero.Instructions/IndexedRoute.cs
@@ -145,7 +145,7 @@ public class IndexedRoute
     /// <returns></returns>
     public int DirectionChangeAt(int shape)
     {
-        return (this.DepartingDirectionAt(shape) - this.ArrivingDirectionAt(shape)).NormalizeDegrees();
+        return (this.ArrivingDirectionAt(shape) - this.DepartingDirectionAt(shape)).NormalizeDegrees();
     }
     //
     // // ReSharper disable once UnusedMember.Global

--- a/src/Itinero.Instructions/Types/Generators/FollowBendGenerator.cs
+++ b/src/Itinero.Instructions/Types/Generators/FollowBendGenerator.cs
@@ -21,9 +21,9 @@ internal class FollowBendGenerator : IInstructionGenerator
         {
             // What is the angle-difference of the branch?
             // This resembles the route.DirectionChangeAt-definition
-            var dBranchAngle =
-                (route.Shape[shapeI].AngleWithMeridian(branch.Coordinate) - route.ArrivingDirectionAt(shapeI))
-                .NormalizeDegrees();
+            var selfAngle = route.ArrivingDirectionAt(shapeI);
+            var branchAngle = route.Shape[shapeI].AngleWithMeridian(branch.Coordinate);
+            var dBranchAngle = (selfAngle - branchAngle).NormalizeDegrees();
 
             // With the angle in hand, we can ask ourselves: lies it on the inner side?
             if (Math.Sign(dBranchAngle) != angleSign)

--- a/src/Itinero.Instructions/Types/Generators/IntersectionInstructionGenerator.cs
+++ b/src/Itinero.Instructions/Types/Generators/IntersectionInstructionGenerator.cs
@@ -28,8 +28,8 @@ internal class IntersectionInstructionGenerator : IInstructionGenerator
         var incomingDirection = route.ArrivingDirectionAt(offset);
         foreach (var branch in branches)
         {
-            var branchAbsDirection = route.Shape[offset].AngleWithMeridian(branch.Coordinate);
-            var branchRelDirection = branchAbsDirection - incomingDirection;
+            var branchAbsDirection = branch.Coordinate.AngleWithMeridian(route.Shape[offset]);
+            var branchRelDirection = incomingDirection - branchAbsDirection;
             incomingStreets.Add((branchRelDirection.NormalizeDegrees(), branch.Attributes));
         }
 

--- a/test/Itinero.Tests/Instructions/BaseInstructionTest.cs
+++ b/test/Itinero.Tests/Instructions/BaseInstructionTest.cs
@@ -30,7 +30,7 @@ public class BaseInstructionTest
         var baseInstruction = new BaseInstructionGenerator().Generate(
             new IndexedRoute(route), 0);
         Assert.NotNull(baseInstruction);
-        Assert.Equal(-90, baseInstruction.TurnDegrees);
+        Assert.Equal(90, baseInstruction.TurnDegrees);
     }
 
     [Fact]
@@ -54,6 +54,6 @@ public class BaseInstructionTest
         var baseInstruction = new BaseInstructionGenerator().Generate(
             new IndexedRoute(route), 0);
         Assert.NotNull(baseInstruction);
-        Assert.Equal(90, baseInstruction.TurnDegrees);
+        Assert.Equal(-90, baseInstruction.TurnDegrees);
     }
 }

--- a/test/Itinero.Tests/Instructions/BearingTest.cs
+++ b/test/Itinero.Tests/Instructions/BearingTest.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Itinero.Instructions;
 using Itinero.Routes;
 using Xunit;
 
@@ -15,12 +14,14 @@ public class BearingTest
     {
         var r = new Route
         {
-            Shape = new List<(double longitude, double latitude, float? e)> {
-                    (3.220161, 51.21578, 0),
-                    (3.220325, 51.21548, 0)
-                }
+            Shape = new List<(double longitude, double latitude, float? e)>
+            {
+                (3.220161, 51.21578, 0), (3.220325, 51.21548, 0)
+            }
         };
         var bearing = r.BearingAt(0);
         Assert.True(158 < bearing && bearing < 162);
     }
+
+
 }

--- a/test/Itinero.Tests/Instructions/FollowBendTest.cs
+++ b/test/Itinero.Tests/Instructions/FollowBendTest.cs
@@ -65,7 +65,7 @@ public class FollowBendTest
             new IndexedRoute(Rabattestraat), 8
         );
         Assert.NotNull(bend);
-        Assert.Equal(-85, bend.TurnDegrees);
+        Assert.Equal(85, bend.TurnDegrees);
         Assert.Equal(8, bend.ShapeIndex);
         Assert.Equal(11, bend.ShapeIndexEnd);
     }
@@ -77,7 +77,7 @@ public class FollowBendTest
             new IndexedRoute(Rabattestraat), 1
         );
         Assert.NotNull(bend);
-        Assert.Equal(143, bend.TurnDegrees);
+        Assert.Equal(-143, bend.TurnDegrees);
         Assert.Equal(1, bend.ShapeIndex);
         Assert.Equal(6, bend.ShapeIndexEnd);
     }
@@ -89,7 +89,7 @@ public class FollowBendTest
             new IndexedRoute(RabattestraatWithOuterBranch), 1
         );
         Assert.NotNull(bend);
-        Assert.Equal(143, bend.TurnDegrees);
+        Assert.Equal(-143, bend.TurnDegrees);
         Assert.Equal(1, bend.ShapeIndex);
         Assert.Equal(6, bend.ShapeIndexEnd);
     }
@@ -102,7 +102,7 @@ public class FollowBendTest
         );
         // We follow the bend, but only until we reach the inner branch
         Assert.NotNull(bend);
-        Assert.Equal(77, bend.TurnDegrees);
+        Assert.Equal(-77, bend.TurnDegrees);
         Assert.Equal(1, bend.ShapeIndex);
         Assert.Equal(3, bend.ShapeIndexEnd);
     }

--- a/test/Itinero.Tests/Instructions/InstructionTest.cs
+++ b/test/Itinero.Tests/Instructions/InstructionTest.cs
@@ -92,7 +92,7 @@ public class InstructionTest
         var texts = instructions.Select(toText.ToText).ToList();
 
         Assert.NotEmpty(instructions);
-        Assert.Equal("Turn 57", texts[1]);
+        Assert.Equal("Turn -57", texts[1]);
     }
 
     [Fact]
@@ -130,6 +130,6 @@ public class InstructionTest
         var instructions = instructionGenerator.GenerateInstructions(route).ToList();
         // The left turn is included in the start instruction
         var leftTurn = ((StartInstruction)instructions[0]).Then;
-        Assert.True(leftTurn.TurnDegrees < 0);
+        Assert.True(leftTurn.TurnDegrees > 0);
     }
 }

--- a/test/Itinero.Tests/Instructions/IntersectionInstructionTest.cs
+++ b/test/Itinero.Tests/Instructions/IntersectionInstructionTest.cs
@@ -162,9 +162,9 @@ public class IntersectionInstructionTest
         };
 
 
-        var instr = (IntersectionInstruction)gen.Generate(new IndexedRoute(route), 1);
+        var instr = (IntersectionInstruction) gen.Generate(new IndexedRoute(route), 1);
         Assert.NotNull(instr);
-        Assert.Equal(0u, instr.ActualIndex);
+        Assert.Equal(1u, instr.ActualIndex);
         Assert.Equal(2, instr.ShapeIndexEnd);
     }
 }

--- a/test/Itinero.Tests/Instructions/RealRouteTests.cs
+++ b/test/Itinero.Tests/Instructions/RealRouteTests.cs
@@ -70,7 +70,7 @@ public class RealRouteTests
         var instructions = gen.GenerateInstructions(route);
         var text = instructions.Select(i => SimpleToText.ToText(i)).ToList();
         Assert.Equal("Start towards 160°", text[0]);
-        Assert.Equal("Turn 87 onto Klaverstraat", text[1]);
+        Assert.Equal("Turn -87 onto Klaverstraat", text[1]);
         Assert.Equal("Fallback: end 0", text[2]);
     }
 


### PR DESCRIPTION
A positive angle turns left, according to mathematical convention. This was implemented wrongly all across the instruction generator and is now fixed