### PR TITLE
Fix route not going over edges that are very short

### DIFF
--- a/src/Itinero/Network/Enumerators/Edges/IEdgeEnumeratorExtensions.cs
+++ b/src/Itinero/Network/Enumerators/Edges/IEdgeEnumeratorExtensions.cs
@@ -38,7 +38,17 @@ public static class IEdgeEnumeratorExtensions
     {
         if (enumerator.Length != null) return enumerator.Length.Value / 100.0;
 
-        return enumerator.GetCompleteShape().DistanceEstimateInMeter();
+        var length = enumerator.GetCompleteShape().DistanceEstimateInMeter();
+
+        // Workaround a problem where 2 nodes in OSM are so close together
+        // that after encoding/decoding their coordinates become same
+        // if we return cost 0, it indicates this is one way road
+        // hence routing doesn't go over it
+        if (length == 0)
+        {
+            length = 0.01; // 1 centimeter
+        }
+        return length;
     }
 
     /// <summary>

--- a/test/Itinero.Tests/Routing/IRouterOneToOneExtensionsTests.cs
+++ b/test/Itinero.Tests/Routing/IRouterOneToOneExtensionsTests.cs
@@ -246,4 +246,29 @@ public class IRouterOneToOneExtensionsTests
         Assert.True((4.802438914775848, 51.268097745847650, (float?)null).DistanceEstimateInMeter(route.Shape[6]) <
                     1);
     }
+
+    [Fact]
+    public async Task IRouterOneToOneExtensions_Two_Vertices_Close_Together()
+    {
+        var (routerDb, _, _) = RouterDbScaffolding.BuildRouterDb([
+                    (5.5253315, 50.6592083,  null),
+                    (5.5245052, 50.6595263,  null),
+                    (5.5245005, 50.6595282,  null),
+                    (5.5241723, 50.6596545,  null)
+                ],
+            [(0, 1, null),
+             (1, 2, null),
+             (2, 3, null)]);
+
+        var network = routerDb.Latest;
+
+        var snap1 = await network.Snap().ToAsync((5.5253315, 50.6592083, null));
+        var snap2 = await network.Snap().ToAsync((5.5241723, 50.6596545, null));
+
+        var result = await routerDb.Latest.Route(new DefaultProfile())
+            .From(snap1).To(snap2).CalculateAsync();
+        Assert.False(result.IsError);
+        var route = result.Value;
+        Assert.NotNull(route.Shape);
+    }
 }


### PR DESCRIPTION
I know this is a bit hacky, but feel free to propose better solution :)
Here is code on how to find such edges:
```csharp
using var ms = new MemoryStream();
using var jsonWriter = new Utf8JsonWriter(ms);
jsonWriter.WriteFeatureCollectionStart();

var latest = routerDb.Latest;
var edgeEnumerator = latest.GetEdgeEnumerator();
foreach (var vertex in latest.GetVertices())
{
    if (!edgeEnumerator.MoveTo(vertex))
    {
        continue;
    }

    while (edgeEnumerator.MoveNext())
    {
        if (!edgeEnumerator.Forward)
        {
            continue;
        }
        var length = edgeEnumerator.EdgeLength();
        if (length == 0)
        {
            jsonWriter.WriteVertexFeature(VertexId.Empty, edgeEnumerator.HeadLocation);
        }
    }
}
jsonWriter.WriteFeatureCollectionEnd();
jsonWriter.Flush();
Console.WriteLine(Encoding.UTF8.GetString(ms.ToArray()));
```

Here is for example output in Slovenia.pbf: [GeoJson.io](https://geojson.io/#data=data:text/x-url,https%3A%2F%2Fgist.githubusercontent.com%2FDavidKarlas%2F674028d1498c4fda057b62447c8168d8%2Fraw%2Ff3daa123c37c0c0236b955c9a6b94b19155b344f%2FSlovenia.pbf.geojson) and [Github Gist](https://gist.github.com/DavidKarlas/674028d1498c4fda057b62447c8168d8)(Click Raw to see actual .geojson)