### PR TITLE
Fix UTurn encoding/decoding failing

### DIFF
--- a/src/Itinero/Network/EdgeId.cs
+++ b/src/Itinero/Network/EdgeId.cs
@@ -15,7 +15,7 @@ public readonly struct EdgeId : IEquatable<EdgeId>
     /// <summary>
     /// The maximum number of internal edges in one tile.
     /// </summary>
-    internal const uint MaxLocalId = (uint.MaxValue / 2) - 1;
+    internal const uint MaxLocalId = (int.MaxValue / 2) - 1;
 
     /// <summary>
     /// Creates a new edge id.

--- a/test/Itinero.Tests/Network/Tiles/NetworkTile.TurnCostsTests.cs
+++ b/test/Itinero.Tests/Network/Tiles/NetworkTile.TurnCostsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Itinero.Network;
 using Itinero.Network.Tiles;
 using Xunit;
 
@@ -131,5 +132,34 @@ public class NetworkTile_TurnCostsTests
                 Assert.Equal(145454U, cost.cost);
             }
         }
+    }
+
+    [Fact]
+    public void NetworkTile_AddTurnCosts_EncodingRoundTrip()
+    {
+        var network = new RoutingNetwork(new RouterDb());
+        var mutable = network.GetAsMutable();
+        var vertex1 = mutable.AddVertex(4.4795, 50.3126);
+        var vertex2 = mutable.AddVertex(4.4782, 50.3188);
+        var vertex3 = mutable.AddVertex(4.4780, 50.3189);
+        var vertex4 = mutable.AddVertex(4.4794, 50.3124);
+
+        var edge1 = mutable.AddEdge(vertex1, vertex2);
+        var edge2 = mutable.AddEdge(vertex2, vertex3);
+        var edge3 = mutable.AddEdge(vertex3, vertex4);
+
+        mutable.AddTurnCosts(vertex3, [("restriction", "no_u_turn"), ("type", "restriction")], [edge2, edge3],
+            new uint[,] { { 0, 1 }, { 0, 0 } }, [edge1]);
+
+        if(mutable.GetTile(vertex3.TileId) is not NetworkTile tile)
+        {
+            throw new Exception("Tile not found.");
+        }
+        var turnCost = tile.GetTurnCosts(vertex3, 1, 0).Single();
+        Assert.Equal(0U, turnCost.turnCostType);
+        Assert.Equal(1U, turnCost.cost);
+        Assert.Equal(1, turnCost.prefixEdges.Count());
+        Assert.Equal(edge1, turnCost.prefixEdges.ElementAt(0));
+        Assert.Equal(2, turnCost.attributes.Count());
     }
 }


### PR DESCRIPTION
I noticed that sometimes UTurn decoding throws exception that happens because the way `NetworkTile.TurnCosts.cs` encodes `prefixEdge` EdgeId. If it is from different tile it does `(int)-(prefixEdge.LocalId + 1)`, but under some conditions this can overflow and resulting `int` is not negative. So when decoding it checks `if (signedLocalId >= 0)` and wrongly assume edge is from same tile, and does not read TileId, resulting in wrong decoding of turncost table size.

It felt like just cutting MaxLocalId in half as easier solution that might solve more problems like this in future. Wondering if cache version should be increased?